### PR TITLE
update tmux Claude shortcuts: Prefix+S for sessions, add split bindings

### DIFF
--- a/KEYBINDS.md
+++ b/KEYBINDS.md
@@ -18,8 +18,10 @@ Prefix key: **Ctrl+b** (default)
 | `prefix -`   | Horizontal split (current directory) |
 | `prefix r`   | Reload tmux config                   |
 | `prefix Tab` | Open popup terminal (75%x80%)        |
-| `prefix C`   | Browse/resume Claude sessions (new window) |
-| `prefix R`   | Resume last Claude session (new window)    |
+| `prefix S`   | Browse/resume Claude sessions (new window)    |
+| `prefix R`   | Resume last Claude session (new window)        |
+| `prefix H`   | Open Claude in horizontal split (current dir)  |
+| `prefix V`   | Open Claude in vertical split (current dir)    |
 
 ### Pane Navigation
 

--- a/home/.tmux.conf
+++ b/home/.tmux.conf
@@ -32,8 +32,10 @@ bind -n M-Up select-pane -U
 bind -n M-Down select-pane -D
 
 bind Tab popup -w 75% -h 80% -d '#{pane_current_path}'
-bind C new-window -c '#{pane_current_path}' 'claude --resume'
+bind S new-window -c '#{pane_current_path}' 'claude --resume'
 bind R new-window -c '#{pane_current_path}' 'claude --continue'
+bind H split-window -h -c '#{pane_current_path}' 'claude'
+bind V split-window -v -c '#{pane_current_path}' 'claude'
 
 tmux_conf_copy_to_os_clipboard=true
 


### PR DESCRIPTION
Change Claude session browse from Prefix+C to Prefix+S. Add Prefix+H and Prefix+V for opening Claude in horizontal/vertical splits.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates local tmux keybindings and documentation; no application logic or data handling changes.
> 
> **Overview**
> Updates tmux Claude shortcuts by moving the *browse/resume sessions* binding from `prefix C` to `prefix S` and keeping `prefix R` for `claude --continue`.
> 
> Adds new `prefix H` and `prefix V` bindings to launch `claude` in horizontal/vertical splits in the current pane’s directory, and documents these changes in `KEYBINDS.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 732a4b5279c33a066d5351a062bd729ffb5aaad2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->