### PR TITLE
Add nvim/tmux Claude integration

### DIFF
--- a/ALIASES.md
+++ b/ALIASES.md
@@ -63,3 +63,5 @@ All ZSH aliases and functions, grouped by source file.
 | `cv` | `tmux split-window -v "claude"` | Open Claude Code in a vertical split |
 | `cv <prompt>` | `tmux split-window -v "claude -p \"...\""` | Open Claude Code with a prompt in a vertical split |
 | `cr` | `tmux new-window "claude --continue"` | Resume last Claude Code session in a new tmux window |
+| `cpi` | `echo 'code' \| cpi 'instruction'` | Pipe stdin to Claude in a new tmux window |
+| `clist` | — | List all tmux panes running Claude across sessions |

--- a/KEYBINDS.md
+++ b/KEYBINDS.md
@@ -22,6 +22,7 @@ Prefix key: **Ctrl+b** (default)
 | `prefix R`   | Resume last Claude session (new window)        |
 | `prefix H`   | Open Claude in horizontal split (current dir)  |
 | `prefix V`   | Open Claude in vertical split (current dir)    |
+| `prefix C`   | Popup listing all active Claude agents         |
 
 ### Pane Navigation
 
@@ -258,6 +259,18 @@ Leader key: **Space**
 | `<leader>pd` | Normal | Delete package         |
 | `<leader>pi` | Normal | Install package        |
 | `<leader>pc` | Normal | Change package version |
+
+### Claude (Tmux Integration)
+
+| Key          | Mode   | Action                                        |
+| ------------ | ------ | --------------------------------------------- |
+| `<leader>zo` | Normal | Open Claude in vertical tmux split            |
+| `<leader>zh` | Normal | Open Claude in horizontal tmux split          |
+| `<leader>zw` | Normal | Open Claude in new tmux window                |
+| `<leader>zs` | Visual | Send selection to Claude (vertical split)     |
+| `<leader>zp` | Visual | Prompt for instruction + send selection       |
+| `<leader>zf` | Normal | Send current file to Claude                   |
+| `<leader>zd` | Normal | Send current line diagnostics to Claude       |
 
 ### Miscellaneous
 

--- a/home/.config/nvim/lua/timopruesse/claude.lua
+++ b/home/.config/nvim/lua/timopruesse/claude.lua
@@ -1,0 +1,152 @@
+local M = {}
+
+local function tmux_pane(mode, cwd)
+	local tmux_arg
+	if mode == "window" then
+		tmux_arg = "new-window"
+	elseif mode == "vsplit" then
+		tmux_arg = "split-window -h"
+	elseif mode == "hsplit" then
+		tmux_arg = "split-window -v"
+	end
+
+	local cmd = string.format("tmux %s -c %s -P -F '#{pane_id}'", tmux_arg, vim.fn.shellescape(cwd))
+	local pane_id = vim.trim(vim.fn.system(cmd))
+	if vim.v.shell_error ~= 0 then
+		vim.notify("tmux: " .. pane_id, vim.log.levels.ERROR)
+		return nil
+	end
+	return pane_id
+end
+
+local function tmux_send(pane_id, keys)
+	vim.fn.jobstart({ "tmux", "send-keys", "-t", pane_id, keys, "Enter" })
+end
+
+function M.get_visual_selection()
+	local lines = vim.fn.getregion(vim.fn.getpos("'<"), vim.fn.getpos("'>"), { type = vim.fn.visualmode() })
+	return table.concat(lines, "\n")
+end
+
+function M.send_to_claude(text, opts)
+	opts = opts or {}
+	local mode = opts.mode or "vsplit"
+	local cwd = vim.fn.getcwd()
+
+	local tmpfile = vim.fn.tempname()
+	local f = io.open(tmpfile, "w")
+	if not f then
+		vim.notify("Failed to create temp file", vim.log.levels.ERROR)
+		return
+	end
+	f:write(text)
+	f:close()
+
+	local pane_id = tmux_pane(mode, cwd)
+	if not pane_id then
+		return
+	end
+
+	local cmd = string.format("claude \"$(cat '%s')\" ; rm -f '%s'", tmpfile, tmpfile)
+	tmux_send(pane_id, cmd)
+end
+
+function M.send_selection(opts)
+	local text = M.get_visual_selection()
+	if text == "" then
+		vim.notify("No selection", vim.log.levels.WARN)
+		return
+	end
+
+	local filepath = vim.fn.expand("%:.")
+	local srow = vim.fn.line("'<")
+	local erow = vim.fn.line("'>")
+	local ft = vim.bo.filetype
+
+	local prompt = string.format("%s:%d-%d\n\n```%s\n%s\n```", filepath, srow, erow, ft, text)
+	M.send_to_claude(prompt, opts)
+end
+
+function M.prompt_and_send(opts)
+	local text = M.get_visual_selection()
+	if text == "" then
+		vim.notify("No selection", vim.log.levels.WARN)
+		return
+	end
+
+	local filepath = vim.fn.expand("%:.")
+	local srow = vim.fn.line("'<")
+	local erow = vim.fn.line("'>")
+	local ft = vim.bo.filetype
+
+	vim.schedule(function()
+		vim.ui.input({ prompt = "Claude: " }, function(input)
+			if not input or input == "" then
+				return
+			end
+
+			local prompt =
+				string.format("%s\n\n%s:%d-%d\n\n```%s\n%s\n```", input, filepath, srow, erow, ft, text)
+			M.send_to_claude(prompt, opts)
+		end)
+	end)
+end
+
+function M.send_file(opts)
+	local filepath = vim.fn.expand("%:.")
+	local ft = vim.bo.filetype
+
+	local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
+	local content = table.concat(lines, "\n")
+
+	local prompt = string.format("File: %s\n\n```%s\n%s\n```", filepath, ft, content)
+	M.send_to_claude(prompt, opts)
+end
+
+function M.send_diagnostics(opts)
+	local lnum = vim.api.nvim_win_get_cursor(0)[1] - 1
+	local diagnostics = vim.diagnostic.get(0, { lnum = lnum })
+
+	if #diagnostics == 0 then
+		vim.notify("No diagnostics on current line", vim.log.levels.INFO)
+		return
+	end
+
+	local filepath = vim.fn.expand("%:.")
+	local ft = vim.bo.filetype
+
+	local diag_texts = {}
+	for _, d in ipairs(diagnostics) do
+		local severity = vim.diagnostic.severity[d.severity]
+		table.insert(diag_texts, string.format("[%s] %s", severity, d.message))
+	end
+
+	local start = math.max(0, lnum - 5)
+	local stop = math.min(vim.api.nvim_buf_line_count(0), lnum + 6)
+	local context_lines = vim.api.nvim_buf_get_lines(0, start, stop, false)
+
+	local prompt = string.format(
+		"Fix the following diagnostics in %s:%d\n\n%s\n\nContext:\n```%s\n%s\n```",
+		filepath,
+		lnum + 1,
+		table.concat(diag_texts, "\n"),
+		ft,
+		table.concat(context_lines, "\n")
+	)
+
+	M.send_to_claude(prompt, opts)
+end
+
+function M.open_claude(opts)
+	opts = opts or {}
+	local mode = opts.mode or "vsplit"
+	local cwd = vim.fn.getcwd()
+
+	local pane_id = tmux_pane(mode, cwd)
+	if not pane_id then
+		return
+	end
+	tmux_send(pane_id, "claude")
+end
+
+return M

--- a/home/.config/nvim/lua/timopruesse/keymaps/claude.lua
+++ b/home/.config/nvim/lua/timopruesse/keymaps/claude.lua
@@ -1,0 +1,29 @@
+local key = require("timopruesse.helpers.keymap")
+local claude = require("timopruesse.claude")
+
+-- open agents
+key.nnoremap("<leader>zo", function()
+	claude.open_claude({ mode = "vsplit" })
+end)
+key.nnoremap("<leader>zh", function()
+	claude.open_claude({ mode = "hsplit" })
+end)
+key.nnoremap("<leader>zw", function()
+	claude.open_claude({ mode = "window" })
+end)
+
+-- send selection
+key.vnoremap("<leader>zs", function()
+	claude.send_selection({ mode = "vsplit" })
+end)
+key.vnoremap("<leader>zp", function()
+	claude.prompt_and_send({ mode = "vsplit" })
+end)
+
+-- send file / diagnostics
+key.nnoremap("<leader>zf", function()
+	claude.send_file({ mode = "vsplit" })
+end)
+key.nnoremap("<leader>zd", function()
+	claude.send_diagnostics({ mode = "vsplit" })
+end)

--- a/home/.config/nvim/lua/timopruesse/keymaps/init.lua
+++ b/home/.config/nvim/lua/timopruesse/keymaps/init.lua
@@ -5,6 +5,7 @@ require("timopruesse.keymaps.harpoon")
 require("timopruesse.keymaps.navigation")
 require("timopruesse.keymaps.luasnip")
 require("timopruesse.keymaps.undotree")
+require("timopruesse.keymaps.claude")
 
 key.nnoremap("<C-s>", key.exec_command("w"))
 

--- a/home/.oh-my-zsh/custom/claude_aliases.zsh
+++ b/home/.oh-my-zsh/custom/claude_aliases.zsh
@@ -40,3 +40,27 @@ function cv() {
 function cr() {
   _claude_tmux window "--continue"
 }
+
+function cpi() {
+  local input=""
+  if [ ! -t 0 ]; then
+    input=$(cat)
+  fi
+  local instruction="$*"
+  local prompt=""
+  if [ -n "$instruction" ] && [ -n "$input" ]; then
+    prompt="${instruction}\n\n${input}"
+  elif [ -n "$input" ]; then
+    prompt="$input"
+  elif [ -n "$instruction" ]; then
+    prompt="$instruction"
+  else
+    echo "Usage: echo 'code' | cpi 'instruction'  OR  cpi 'prompt'"
+    return 1
+  fi
+  _claude_tmux window "-p $(printf '%q' "$prompt")"
+}
+
+function clist() {
+  tmux list-panes -a -F '#{session_name}:#{window_index}.#{pane_index}  #{pane_current_command}  #{pane_current_path}' 2>/dev/null | grep -i claude || echo "No Claude agents running"
+}

--- a/home/.tmux.conf
+++ b/home/.tmux.conf
@@ -36,6 +36,7 @@ bind S new-window -c '#{pane_current_path}' 'claude --resume'
 bind R new-window -c '#{pane_current_path}' 'claude --continue'
 bind H split-window -h -c '#{pane_current_path}' 'claude'
 bind V split-window -v -c '#{pane_current_path}' 'claude'
+bind C display-popup -w 60% -h 40% -E 'tmux list-panes -a -F "#{session_name}:#{window_index}.#{pane_index}  #{pane_current_command}  #{pane_current_path}" | grep -i claude || echo "No Claude agents running"; read -n 1'
 
 tmux_conf_copy_to_os_clipboard=true
 


### PR DESCRIPTION
## Summary
- New Neovim module (`claude.lua`) to send code/files/diagnostics to Claude via tmux splits
- Neovim keymaps under `<leader>z` prefix: open agents (`zo/zh/zw`), send selection (`zs`), prompt + send (`zp`), send file (`zf`), send diagnostics (`zd`)
- Shell functions: `cpi` (pipe stdin to Claude), `clist` (list active Claude agents)
- Tmux `Prefix+C` popup listing all active Claude agents
- Updated KEYBINDS.md and ALIASES.md documentation

## Test plan
- [x] `<leader>zo` opens Claude in a vertical tmux split
- [x] `<leader>zs` sends visual selection to Claude interactively
- [x] `<leader>zp` prompts for instruction then sends selection
- [x] `cpi` and `clist` shell functions
- [x] `Prefix+C` tmux popup

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it introduces new command-execution paths (tmux + shelling out to `claude`) and keybinds/aliases that could misbehave due to quoting or tmux pane targeting, but changes are confined to developer tooling/dotfiles.
> 
> **Overview**
> Adds a Neovim-to-tmux integration for sending context to Claude: a new `timopruesse/claude.lua` module can open a tmux pane/window and push prompts built from the visual selection, the current file, or current-line diagnostics.
> 
> Wires this into new Neovim mappings under `<leader>z` and updates tmux/zsh tooling: adds `cpi` (pipe stdin + optional instruction into a Claude prompt) and `clist`, plus a new tmux `prefix C` popup to list active Claude panes; docs in `KEYBINDS.md`/`ALIASES.md` are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 162ae5e5d6a0cad6df2b544db945621911cdd47c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->