### PR TITLE
Update README with accurate project info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 # .dotfiles
 
-## TLDR;
+Declarative, YAML-driven dotfiles for a WSL2 development environment. Managed by [machine_setup](https://github.com/timopruesse/machine_setup).
 
-- neovim
-  - color scheme: [PaperColor](https://github.com/NLKNguyen/papercolor-theme)
-- tmux
-  - separate sessions for personal/work
-- WSL (Ubuntu)
-- Windows Terminal Preview
+## Overview
+
+- **Editor**: Neovim (Lua, [Lazy.nvim](https://github.com/folke/lazy.nvim)) with [Catppuccin Mocha](https://github.com/catppuccin/nvim) theme
+- **Shell**: Zsh + [Oh My Zsh](https://ohmyz.sh/) + [Powerlevel10k](https://github.com/romkatv/powerlevel10k)
+- **Terminal**: [Windows Terminal Preview](https://github.com/timopruesse/.dotfiles/blob/main/terminal/settings.json) + tmux (also Catppuccin themed)
+- **OS**: WSL2 (Ubuntu) on Windows
+- **AI**: Claude Code integration in both Neovim and tmux
 
 ## Keybinds
 
@@ -17,14 +18,19 @@ See [KEYBINDS.md](KEYBINDS.md) for a full reference of Tmux and Neovim keybindin
 
 See [ALIASES.md](ALIASES.md) for all ZSH aliases grouped by category.
 
-## Editor
+## Neovim
 
-My `neovim` configuration is written in `lua` and can be found [here](https://github.com/timopruesse/.dotfiles/tree/main/home/.config/nvim).
+The config is written in Lua and lives in [`home/.config/nvim/`](https://github.com/timopruesse/.dotfiles/tree/main/home/.config/nvim). Key features:
 
-## OS
+- LSP via mason.nvim + nvim-lspconfig
+- Format on save via conform.nvim (Prettier, rustfmt, stylua, black, shfmt, goimports)
+- Telescope for fuzzy finding
+- LuaSnip snippets for JS, Rust, Lua, Svelte
 
-I'm using the `WSL` within Windows and the following distro: [Ubuntu 22.04](https://apps.microsoft.com/store/detail/ubuntu-2204-lts/9PN20MSR04DW).
+## How It Works
 
-## Terminal
+The `home/` directory is symlinked to `~`, so edits take effect immediately. System-level files (`etc/wsl.conf`, `terminal/settings.json`) are copied by the setup tool. See `machine_setup.yaml` for the full task list.
 
-`Windows Terminal Preview` ([settings](https://github.com/timopruesse/.dotfiles/blob/main/terminal/settings.json)) + `tmux`
+## Languages & Tools
+
+Managed via `machine_setup.yaml`: Rust (nightly), Node (nvm), Bun, Deno, Python, Go, Dart/Flutter, plus lazygit, ripgrep, eza, zoxide, and fzf.


### PR DESCRIPTION
## Summary
- Fix outdated color scheme (PaperColor → Catppuccin Mocha) and stale Ubuntu 22.04 link
- Add missing context: shell stack, Claude Code integration, Neovim features, language toolchains
- Add "How It Works" section explaining the symlink-based setup

## Test plan
- [x] Verify all links point to correct targets
- [x] Cross-checked against actual config files (theme.lua, .tmux.conf, .zshrc, machine_setup.yaml)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; no code or configuration behavior is modified.
> 
> **Overview**
> Replaces the outdated README TL;DR with a clearer **Overview** of the current environment (Neovim + Catppuccin, Zsh/Oh My Zsh/Powerlevel10k, Windows Terminal + tmux, and Claude Code integration).
> 
> Adds a **Neovim** section summarizing key capabilities (LSP, format-on-save tooling, Telescope, snippets) and a **How It Works** section documenting the symlinked `home/` workflow and which files are copied by `machine_setup`, plus an updated **Languages & Tools** list managed via `machine_setup.yaml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e138b5e7deb184fb496cc88c912e933e7e977cce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->