### PR TITLE
fix claude wrapper for repos without commits

### DIFF
--- a/home/.zshrc
+++ b/home/.zshrc
@@ -164,9 +164,9 @@ case ":$PATH:" in
 esac
 # pnpm end
 
-# claude code: use worktree when inside a git repo
+# claude code: use worktree when inside a git repo with commits
 claude() {
-  if git rev-parse --is-inside-work-tree &>/dev/null; then
+  if git rev-parse --is-inside-work-tree &>/dev/null && git rev-parse HEAD &>/dev/null; then
     command claude "$@" --worktree
   else
     command claude "$@"


### PR DESCRIPTION
## Summary
- Add `git rev-parse HEAD` check to the claude wrapper so `--worktree` is only passed when the repo has at least one commit
- Prevents "Failed to resolve base branch HEAD" errors in newly initialized repos with no upstream

## Test plan
- [x] Run `claude` in a repo with no commits — should launch without `--worktree`
- [x] Run `claude` in a normal repo — should still use `--worktree`
- [x] Run `claude` outside a git repo — should still work without `--worktree`

🤖 Generated with [Claude Code](https://claude.com/claude-code)