### PR TITLE
show window name in claude picker and fix status bar cutoff

### DIFF
--- a/home/.tmux.conf
+++ b/home/.tmux.conf
@@ -59,4 +59,5 @@ set -g @catppuccin_flavor 'mocha'
 run '~/.tmux/plugins/tpm/tpm'
 
 # claude agent count in status bar (after tpm so it appends to theme's status-right)
+set -g status-right-length 200
 set -ga status-right '#[fg=#cba6f7] #(~/.tmux/scripts/claude_count.sh)'

--- a/home/.tmux/scripts/claude_picker.sh
+++ b/home/.tmux/scripts/claude_picker.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-panes=$(tmux list-panes -a -F '#{session_name}:#{window_index}.#{pane_index}  #{pane_current_command}  #{pane_current_path}' 2>/dev/null | grep -i claude)
+panes=$(tmux list-panes -a -F '#{pane_current_command} #{session_name}:#{window_index}.#{pane_index}  [#{window_name}]  #{pane_current_path}' 2>/dev/null | grep -i '^claude ' | sed 's/^[^ ]* //')
 
 if [ -z "$panes" ]; then
   echo "No Claude agents running"


### PR DESCRIPTION
## Summary
- Show window/tab name in the Claude agent picker so worktrees are identifiable
- Fix status bar cutoff by setting `status-right-length 200`

🤖 Generated with [Claude Code](https://claude.com/claude-code)